### PR TITLE
Corregir redirección de botones a tally.so

### DIFF
--- a/CHANGES_SUMMARY.md
+++ b/CHANGES_SUMMARY.md
@@ -1,0 +1,69 @@
+# Button Fixes Summary
+
+## Changes Made
+
+All "Empezar ahora" and CTA buttons now redirect to tally.so as requested.
+
+### 1. Created New Navigation Component
+- **File**: `src/components/Navigation.tsx`
+- **Features**: 
+  - Fixed navigation header with "sesfy" logo and "Plataforma Líder en Gestión Fiscal" tagline
+  - Menu items: Inicio, Cómo funciona, Beneficios, Testimonios, FAQ
+  - "Empezar ahora" button that redirects to tally.so
+  - Mobile responsive with hamburger menu
+
+### 2. Fixed Hero Section Button
+- **File**: `src/components/HeroSection.tsx`
+- **Change**: "Quiero que me lleven los impuestos" button now redirects to tally.so instead of scrolling to contact section
+- **Added**: Section ID "inicio" and top padding for fixed navigation
+
+### 3. Fixed CTA Section Buttons
+- **File**: `src/components/CTASection.tsx`
+- **Changes**: Both CTA buttons now redirect to tally.so:
+  - "Quiero hablar con un asesor"
+  - "Solo quiero más info por ahora"
+
+### 4. Fixed FAQ Section Button
+- **File**: `src/components/FAQSection.tsx`
+- **Change**: "Contáctanos directamente" button now redirects to tally.so
+- **Added**: Section ID "faq"
+
+### 5. Added Navigation to Main Layout
+- **File**: `src/pages/Index.tsx`
+- **Change**: Added Navigation component to the top of the page
+
+### 6. Added Section IDs for Navigation
+- **Files**: All section components
+- **Changes**: Added proper IDs for smooth scrolling navigation:
+  - `#inicio` (HeroSection)
+  - `#como-funciona` (HowItWorksSection)
+  - `#beneficios` (BenefitsSection)
+  - `#testimonios` (TestimonialsSection)
+  - `#faq` (FAQSection)
+
+### 7. Created Constants File
+- **File**: `src/lib/constants.ts`
+- **Purpose**: Centralized tally.so URL configuration for easy management
+- **Usage**: All buttons now import from `EXTERNAL_LINKS.TALLY_FORM`
+
+## URL Configuration
+
+**Current placeholder URL**: `https://tally.so/r/your-form-id`
+
+**To update the actual tally.so URL**: 
+Edit the `TALLY_FORM` value in `/src/lib/constants.ts`
+
+## Buttons Fixed
+
+1. ✅ Navigation "Empezar ahora" button (header)
+2. ✅ Hero section "Quiero que me lleven los impuestos" button
+3. ✅ CTA section "Quiero hablar con un asesor" button
+4. ✅ CTA section "Solo quiero más info por ahora" button
+5. ✅ FAQ section "Contáctanos directamente" button
+
+All buttons now open tally.so in a new tab when clicked.
+
+## Build Status
+✅ Application builds successfully
+✅ All TypeScript errors resolved
+✅ All imports working correctly

--- a/src/components/BenefitsSection.tsx
+++ b/src/components/BenefitsSection.tsx
@@ -29,7 +29,7 @@ const benefits = [
 
 const BenefitsSection = () => {
   return (
-    <section className="py-20 bg-background">
+    <section id="beneficios" className="py-20 bg-background">
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-16 animate-fade-in">
           <h2 className="text-3xl sm:text-4xl lg:text-5xl font-bold mb-6">

--- a/src/components/CTASection.tsx
+++ b/src/components/CTASection.tsx
@@ -1,5 +1,6 @@
 import { ArrowRight, Phone, Info } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { EXTERNAL_LINKS } from "@/lib/constants";
 import advisorImage from "@/assets/advisor-illustration.jpg";
 
 const CTASection = () => {
@@ -46,6 +47,7 @@ const CTASection = () => {
               <Button 
                 size="lg"
                 className="bg-white text-primary hover:bg-gray-100 font-semibold px-8 py-4 rounded-xl shadow-lg hover:shadow-xl transform hover:-translate-y-1 transition-all duration-300 group"
+                onClick={() => window.open(EXTERNAL_LINKS.TALLY_FORM, '_blank')}
               >
                 <Phone className="mr-2 w-5 h-5 group-hover:rotate-12 transition-transform" />
                 Quiero hablar con un asesor
@@ -55,6 +57,7 @@ const CTASection = () => {
                 size="lg"
                 variant="secondary"
                 className="bg-white/10 border-white/20 text-white hover:bg-white/20 hover:text-white font-semibold px-8 py-4 rounded-xl backdrop-blur-sm transition-all duration-300 group"
+                onClick={() => window.open(EXTERNAL_LINKS.TALLY_FORM, '_blank')}
               >
                 <Info className="mr-2 w-5 h-5 group-hover:scale-110 transition-transform" />
                 Solo quiero más info por ahora

--- a/src/components/FAQSection.tsx
+++ b/src/components/FAQSection.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { ChevronDown, Shield, User, FileText, MessageCircle } from "lucide-react";
+import { EXTERNAL_LINKS } from "@/lib/constants";
 
 const faqs = [
   {
@@ -36,7 +37,7 @@ const FAQSection = () => {
   };
 
   return (
-    <section className="py-20 bg-secondary/30">
+    <section id="faq" className="py-20 bg-secondary/30">
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-16 animate-fade-in">
           <h2 className="text-3xl sm:text-4xl lg:text-5xl font-bold mb-6">
@@ -105,7 +106,10 @@ const FAQSection = () => {
               <p className="mb-4 opacity-90">
                 Nuestro equipo está aquí para ayudarte con cualquier duda
               </p>
-              <button className="bg-white text-primary px-6 py-3 rounded-lg font-semibold hover:bg-gray-100 transition-colors">
+              <button 
+                className="bg-white text-primary px-6 py-3 rounded-lg font-semibold hover:bg-gray-100 transition-colors"
+                onClick={() => window.open(EXTERNAL_LINKS.TALLY_FORM, '_blank')}
+              >
                 Contáctanos directamente
               </button>
             </div>

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,10 +1,11 @@
 import { ArrowRight, CheckCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { EXTERNAL_LINKS } from "@/lib/constants";
 import heroImage from "@/assets/hero-image.jpg";
 
 const HeroSection = () => {
   return (
-    <section className="relative min-h-screen flex items-center justify-center bg-gradient-hero overflow-hidden">
+    <section id="inicio" className="relative min-h-screen flex items-center justify-center bg-gradient-hero overflow-hidden pt-16">
       {/* Background decoration */}
       <div className="absolute inset-0 z-0">
         <div className="absolute top-20 left-10 w-72 h-72 bg-primary/10 rounded-full blur-3xl animate-float"></div>
@@ -46,7 +47,7 @@ const HeroSection = () => {
             <Button 
               size="lg"
               className="btn-hero group"
-              onClick={() => document.getElementById('contact')?.scrollIntoView({ behavior: 'smooth' })}
+              onClick={() => window.open(EXTERNAL_LINKS.TALLY_FORM, '_blank')}
             >
               Quiero que me lleven los impuestos
               <ArrowRight className="ml-2 w-5 h-5 group-hover:translate-x-1 transition-transform" />

--- a/src/components/HowItWorksSection.tsx
+++ b/src/components/HowItWorksSection.tsx
@@ -76,6 +76,7 @@ const HowItWorksSection = () => {
 
   return (
     <section 
+      id="como-funciona"
       ref={sectionRef}
       className="py-20 bg-gradient-to-br from-secondary/20 to-primary-light/30 relative overflow-hidden"
     >

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,0 +1,102 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Menu, X } from "lucide-react";
+import { EXTERNAL_LINKS } from "@/lib/constants";
+
+const Navigation = () => {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+  const handleStartNow = () => {
+    window.open(EXTERNAL_LINKS.TALLY_FORM, '_blank');
+  };
+
+  const menuItems = [
+    { label: "Inicio", href: "#inicio" },
+    { label: "Cómo funciona", href: "#como-funciona" },
+    { label: "Beneficios", href: "#beneficios" },
+    { label: "Testimonios", href: "#testimonios" },
+    { label: "FAQ", href: "#faq" },
+  ];
+
+  return (
+    <nav className="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-200">
+      <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex items-center justify-between h-16">
+          {/* Logo */}
+          <div className="flex items-center">
+            <div className="flex items-center gap-2">
+              <div className="w-8 h-8 bg-gradient-to-r from-primary to-purple rounded-lg flex items-center justify-center">
+                <span className="text-white font-bold text-sm">S</span>
+              </div>
+              <span className="text-xl font-bold text-gray-900">sesfy</span>
+            </div>
+            <div className="hidden sm:block ml-4 px-3 py-1 bg-primary/10 rounded-full">
+              <span className="text-sm text-primary font-medium">Plataforma Líder en Gestión Fiscal</span>
+            </div>
+          </div>
+
+          {/* Desktop Menu */}
+          <div className="hidden md:flex items-center space-x-8">
+            {menuItems.map((item) => (
+              <a
+                key={item.label}
+                href={item.href}
+                className="text-gray-600 hover:text-primary transition-colors font-medium"
+              >
+                {item.label}
+              </a>
+            ))}
+          </div>
+
+          {/* CTA Button */}
+          <div className="hidden md:block">
+            <Button 
+              onClick={handleStartNow}
+              className="bg-primary hover:bg-primary-dark text-white font-semibold px-6 py-2 rounded-lg transition-all duration-300 hover:shadow-lg"
+            >
+              Empezar ahora
+            </Button>
+          </div>
+
+          {/* Mobile menu button */}
+          <div className="md:hidden">
+            <button
+              onClick={() => setIsMenuOpen(!isMenuOpen)}
+              className="text-gray-600 hover:text-primary transition-colors"
+            >
+              {isMenuOpen ? <X className="w-6 h-6" /> : <Menu className="w-6 h-6" />}
+            </button>
+          </div>
+        </div>
+
+        {/* Mobile Menu */}
+        {isMenuOpen && (
+          <div className="md:hidden">
+            <div className="px-2 pt-2 pb-3 space-y-1 bg-white border-t border-gray-200">
+              {menuItems.map((item) => (
+                <a
+                  key={item.label}
+                  href={item.href}
+                  className="block px-3 py-2 text-gray-600 hover:text-primary transition-colors font-medium"
+                  onClick={() => setIsMenuOpen(false)}
+                >
+                  {item.label}
+                </a>
+              ))}
+              <div className="pt-2">
+                <Button 
+                  onClick={handleStartNow}
+                  className="w-full bg-primary hover:bg-primary-dark text-white font-semibold py-2 rounded-lg transition-all duration-300"
+                >
+                  Empezar ahora
+                </Button>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </nav>
+  );
+};
+
+export default Navigation;

--- a/src/components/TestimonialsSection.tsx
+++ b/src/components/TestimonialsSection.tsx
@@ -71,7 +71,7 @@ const TestimonialsSection = () => {
   };
 
   return (
-    <section className="py-20 bg-gradient-hero">
+    <section id="testimonios" className="py-20 bg-gradient-hero">
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-16 animate-fade-in">
           <h2 className="text-3xl sm:text-4xl lg:text-5xl font-bold mb-6">

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,5 @@
+// Centralized configuration for external links
+export const EXTERNAL_LINKS = {
+  // TODO: Replace with the actual tally.so form URL
+  TALLY_FORM: "https://tally.so/r/your-form-id",
+};

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,3 +1,4 @@
+import Navigation from "@/components/Navigation";
 import HeroSection from "@/components/HeroSection";
 import HowItWorksSection from "@/components/HowItWorksSection";
 import BenefitsSection from "@/components/BenefitsSection";
@@ -8,6 +9,7 @@ import CTASection from "@/components/CTASection";
 const Index = () => {
   return (
     <div className="min-h-screen">
+      <Navigation />
       <HeroSection />
       <HowItWorksSection />
       <BenefitsSection />


### PR DESCRIPTION
Fix non-functional "Empezar ahora" and CTA buttons by redirecting them to tally.so and introduce a new navigation bar.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-76f2f95f-da43-4761-8866-21dd857aeb82) · [Cursor](https://cursor.com/background-agent?bcId=bc-76f2f95f-da43-4761-8866-21dd857aeb82)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)